### PR TITLE
Update toast transitions to Bootstrap 5.2

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -81,6 +81,7 @@
 						],
 						"styles": [
 							"node_modules/bootstrap/dist/css/bootstrap.css",
+							"node_modules/bootstrap-icons/font/bootstrap-icons.css",
 							"node_modules/prismjs/themes/prism.css",
 							"demo/src/style/app.scss",
 							"demo/src/style/demos.css"

--- a/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.html
+++ b/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.html
@@ -33,7 +33,7 @@
 						ngbDatepicker
 						#d2="ngbDatepicker"
 					/>
-					<button class="btn btn-outline-secondary calendar" (click)="d2.toggle()" type="button"></button>
+					<button class="btn btn-outline-secondary bi bi-calendar3" (click)="d2.toggle()" type="button"></button>
 				</div>
 			</div>
 		</form>

--- a/demo/src/app/components/datepicker/demos/config/datepicker-config.html
+++ b/demo/src/app/components/datepicker/demos/config/datepicker-config.html
@@ -11,7 +11,7 @@
 				ngbDatepicker
 				#d="ngbDatepicker"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
@@ -13,7 +13,7 @@
 				[markDisabled]="isDisabled"
 				#d="ngbDatepicker"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>

--- a/demo/src/app/components/datepicker/demos/footertemplate/datepicker-footertemplate.html
+++ b/demo/src/app/components/datepicker/demos/footertemplate/datepicker-footertemplate.html
@@ -15,7 +15,7 @@
 				[footerTemplate]="footerTemplate"
 				#d="ngbDatepicker"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
@@ -22,7 +22,7 @@
 				ngbDatepicker
 				#d="ngbDatepicker"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>

--- a/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
+++ b/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
@@ -9,7 +9,7 @@
 				ngbDatepicker
 				#d="ngbDatepicker"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>
@@ -18,6 +18,6 @@
 <pre>Model: {{ model | json }}</pre>
 
 <ngb-alert class="mt-3 mb-0" type="info" [dismissible]="false">
-	You must provide the icon for the button. This allows you to choose an icon that matches your application's style. In
-	this example, the icon is set via a CSS class.
+	You must provide the icon for the button that matches your application's style. In this example, the icon comes from
+	<code>bootstrap-icons</code>.
 </ngb-alert>

--- a/demo/src/app/components/datepicker/demos/positiontarget/datepicker-positiontarget.html
+++ b/demo/src/app/components/datepicker/demos/positiontarget/datepicker-positiontarget.html
@@ -16,7 +16,7 @@
 				[placement]="placement"
 				[positionTarget]="buttonEl"
 			/>
-			<button #buttonEl class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+			<button #buttonEl class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>

--- a/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.html
+++ b/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.html
@@ -38,7 +38,7 @@
 				[value]="formatter.format(fromDate)"
 				(input)="fromDate = validateInput(fromDate, dpFromDate.value)"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="datepicker.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="datepicker.toggle()" type="button"></button>
 		</div>
 	</div>
 	<div class="col-12">
@@ -51,7 +51,7 @@
 				[value]="formatter.format(toDate)"
 				(input)="toDate = validateInput(toDate, dpToDate.value)"
 			/>
-			<button class="btn btn-outline-secondary calendar" (click)="datepicker.toggle()" type="button"></button>
+			<button class="btn btn-outline-secondary bi bi-calendar3" (click)="datepicker.toggle()" type="button"></button>
 		</div>
 	</div>
 </form>

--- a/demo/src/app/components/modal/demos/basic/modal-basic.html
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.html
@@ -16,7 +16,7 @@
 						ngbDatepicker
 						#dp="ngbDatepicker"
 					/>
-					<button class="btn btn-outline-secondary calendar" (click)="dp.toggle()" type="button"></button>
+					<button class="btn btn-outline-secondary bi bi-calendar3" (click)="dp.toggle()" type="button"></button>
 				</div>
 			</div>
 		</form>

--- a/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.html
+++ b/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.html
@@ -16,7 +16,7 @@
 						ngbDatepicker
 						#dp="ngbDatepicker"
 					/>
-					<button class="btn btn-outline-secondary calendar" (click)="dp.toggle()" type="button"></button>
+					<button class="btn btn-outline-secondary bi bi-calendar3" (click)="dp.toggle()" type="button"></button>
 				</div>
 			</div>
 		</form>

--- a/demo/src/app/components/rating/demos/decimal/rating-decimal.html
+++ b/demo/src/app/components/rating/demos/decimal/rating-decimal.html
@@ -1,9 +1,11 @@
-<p>Custom rating template provided via a variable. Shows fine-grained rating display</p>
+<p>Custom readonly decimal rating with template provided via an input</p>
+
+<p>We use <code>bootstrap-icons</code> to display hearts</p>
 
 <ng-template #t let-fill="fill">
-	<span class="star" [class.full]="fill === 100">
-		<span class="half" [style.width.%]="fill">&hearts;</span>&hearts;
-	</span>
+	<i class="bi-heart-fill">
+		<i *ngIf="fill > 0" class="bi-heart-fill filled" [style.width.%]="fill"></i>
+	</i>
 </ng-template>
 
 <ngb-rating [(rate)]="currentRate" [starTemplate]="t" [readonly]="true" [max]="5"></ngb-rating>

--- a/demo/src/app/components/rating/demos/decimal/rating-decimal.ts
+++ b/demo/src/app/components/rating/demos/decimal/rating-decimal.ts
@@ -5,20 +5,20 @@ import { Component } from '@angular/core';
 	templateUrl: './rating-decimal.html',
 	styles: [
 		`
-			.star {
+			i {
 				position: relative;
 				display: inline-block;
-				font-size: 3rem;
+				font-size: 2.5rem;
+				padding-right: 0.1rem;
 				color: #d3d3d3;
 			}
-			.full {
+
+			.filled {
 				color: red;
-			}
-			.half {
-				position: absolute;
-				display: inline-block;
 				overflow: hidden;
-				color: red;
+				position: absolute;
+				top: 0;
+				left: 0;
 			}
 		`,
 	],

--- a/demo/src/app/components/rating/demos/template/rating-template.html
+++ b/demo/src/app/components/rating/demos/template/rating-template.html
@@ -1,8 +1,10 @@
 <p>Custom rating template provided as child element</p>
 
+<p>We use <code>bootstrap-icons</code> to display stars</p>
+
 <ngb-rating [(rate)]="currentRate">
 	<ng-template let-fill="fill" let-index="index">
-		<span class="star" [class.filled]="fill === 100" [class.bad]="index < 3">&#9733;</span>
+		<i class="bi-star{{fill === 100 ? '-fill' : ''}}" [class.filled]="fill === 100" [class.low]="index < 3"></i>
 	</ng-template>
 </ngb-rating>
 <hr />

--- a/demo/src/app/components/rating/demos/template/rating-template.ts
+++ b/demo/src/app/components/rating/demos/template/rating-template.ts
@@ -5,17 +5,18 @@ import { Component } from '@angular/core';
 	templateUrl: './rating-template.html',
 	styles: [
 		`
-			.star {
+			i {
 				font-size: 1.5rem;
+				padding-right: 0.1rem;
 				color: #b0c4de;
 			}
 			.filled {
 				color: #1e90ff;
 			}
-			.bad {
+			.low {
 				color: #deb0b0;
 			}
-			.filled.bad {
+			.filled.low {
 				color: #ff1e1e;
 			}
 		`,

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -384,6 +384,7 @@ pre[class*='language-'],
 ngb-alert {
 	background-color: #f5f5f5; // same as bootstrap card header
 	border-radius: 3px;
+	tab-size: 2;
 }
 
 span.token.tag {

--- a/demo/src/style/demos.css
+++ b/demo/src/style/demos.css
@@ -1,14 +1,3 @@
-/* Datepicker popup icon */
-
-button.calendar,
-button.calendar:active {
-	width: 2.75rem;
-	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACIAAAAcCAYAAAAEN20fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAEUSURBVEiJ7ZQxToVAEIY/YCHGxN6XGOIpnpaEsBSeQC9ArZbm9TZ6ADyBNzAhQGGl8Riv4BLAWAgmkpBYkH1b8FWT2WK/zJ8ZJ4qiI6XUI3ANnGKWBnht2/ZBDRK3hgVGNsCd7/ui+JkEIrKtqurLpEWaphd933+IyI3LEIdpCYCiKD6HcuOa/nwOa0ScJEnk0BJg0UTUWJRl6RxCYEzEmomsIlPU3IPW+grIAbquy+q6fluy/28RIBeRMwDXdXMgXLj/B2uimRXpui4D9sBeRLKl+1N+L+t6RwbWrZliTTTr1oxYtzVWiTQAcRxvTX+eJMnlUDaO1vpZRO5NS0x48sIwfPc87xg4B04MCzQi8hIEwe4bl1DnFMCN2zsAAAAASUVORK5CYII=') !important;
-	background-repeat: no-repeat;
-	background-size: 23px;
-	background-position: center;
-}
-
 /* Sortable table demo */
 
 th[sortable] {

--- a/misc/generate-stackblitzes.ts
+++ b/misc/generate-stackblitzes.ts
@@ -10,6 +10,7 @@ const packageJson = fs.readJsonSync('package.json');
 
 const versions = {
 	ngBootstrap: packageJson.version,
+	bootstrapIcons: getVersion('bootstrap-icons'),
 	angular: getVersion('@angular/core'),
 	typescript: getVersion('typescript'),
 	rxjs: getVersion('rxjs'),

--- a/misc/stackblitzes-templates/index.html.ejs
+++ b/misc/stackblitzes-templates/index.html.ejs
@@ -3,8 +3,8 @@
 
 <head>
   <title>ng-bootstrap <%=componentName%> demo - <%=demoName%></title>
-  <link rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@<%=versions.bootstrap%>/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@<%=versions.bootstrap%>/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@<%=versions.bootstrapIcons%>/font/bootstrap-icons.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/<%=versions.prismjs%>/themes/prism.css" />
   <style>
     <%-styles%>

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "bootstrap": "5.2.0",
+    "bootstrap-icons": "1.9.1",
     "conventional-changelog-cli": "^2.0.12",
     "coverage-istanbul-loader": "^3.0.3",
     "cross-spawn": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,6 +3548,11 @@ boolean@^3.0.1:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.4.tgz#f51a2fb5838a99e06f9b6ec1edb674de67026435"
   integrity sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==
 
+bootstrap-icons@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz#cf22d91a25447645e45c49ebde4e56eafdfe761b"
+  integrity sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g==
+
 bootstrap@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.0.tgz#838727fb60f1630db370fe57c63cbcf2962bb3d3"


### PR DESCRIPTION
Toast animations have been broken since Bootstrap 5.2, which changed it's internal animation api.This PR has removed the usage of the class `hide` (not necessary anymore according to the docs) and tries to mimic the way the bootstrap.js handles transitions.